### PR TITLE
Deduplicate, sort output from cert_database lookup

### DIFF
--- a/sublert.py
+++ b/sublert.py
@@ -165,7 +165,7 @@ class cert_database(object): #Connecting to crt.sh public API to retrieve subdom
         if wildcard:
             domain = "%25.{}".format(domain)
             url = base_url.format(domain)
-        subdomains = []
+        subdomains = set()
         user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101 Firefox/64.0'
 
         try:
@@ -175,14 +175,14 @@ class cert_database(object): #Connecting to crt.sh public API to retrieve subdom
                     content = req.content.decode('utf-8')
                     data = json.loads(content)
                     for subdomain in data:
-                        subdomains.append(subdomain["name_value"])
-                    return subdomains
+                        subdomains.add(subdomain["name_value"])
+                    return sorted(subdomains)
                 except:
                     error = "Error retrieving information for {}.".format(domain.replace('%25.', ''))
                     errorlog(error, enable_logging)
         except:
             try: #connecting to crt.sh postgres database to retrieve subdomains in case API fails
-                unique_domains = []
+                unique_domains = set()
                 domain = domain.replace('%25.', '')
                 conn = psycopg2.connect("dbname={0} user={1} host={2}".format(DB_NAME, DB_USER, DB_HOST))
                 conn.autocommit = True
@@ -193,9 +193,9 @@ class cert_database(object): #Connecting to crt.sh public API to retrieve subdom
                     for subdomain in matches:
                         try:
                             if get_fld("https://" + subdomain) == domain:
-                                unique_domains.append(subdomain)
+                                unique_domains.add(subdomain)
                         except: pass
-                return unique_domains
+                return sorted(unique_domains)
             except:
                 print(colored("[!] Unable to connect to the database.".format(domain), "red"))
                 error = "Unable to connect to the database."


### PR DESCRIPTION
`cert_database.lookup()` uses a list for storing subdomains, but the
respose from the service can contain (many) duplicate subdomains.  In
addition, the subdomain list is not in a deterministic order, so future
diffs may be inaccurate.

This PR switches from a list to a `set` for storing the subdomains,
which automatically deduplicates them.  It also returns a sorted
version, guaranteeing a consistent order for every call.

I tested this using the `python.org` domain, before and after applying the code in this PR:

```
$ wc -l python.org.txt.before python.org.txt.after
    1696 python.org.txt.before
      40 python.org.txt.after
```

You can see there are a _lot_ of duplicates for this domain.  `paypal.com` was worse at 7550 before and 2031 after.

This issue is very evident when using Slack, as the code makes individual requests to the Slack API for each subdomain; with a lot of subdomains this can take hours.
